### PR TITLE
Create rubi-rs.md

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -133,7 +133,7 @@ const navigation = [
         ],
       },
      {
-        title: 'rubi-rs',
+        title: 'Rust SDK',
         href: '/docs/api/rubi-rs',
       },
     ],

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -132,6 +132,10 @@ const navigation = [
           },
         ],
       },
+     {
+        title: 'Rust SDK',
+        href: '/docs/api/rubi-rs',
+      },
     ],
   },
 ]

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -134,7 +134,7 @@ const navigation = [
       },
      {
         title: 'Rust SDK',
-        href: '/docs/api/rubi-rs',
+        href: '/docs/api/subgraphs/rubi-rs',
       },
     ],
   },

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -133,7 +133,7 @@ const navigation = [
         ],
       },
      {
-        title: 'Rust SDK',
+        title: 'rubi-rs',
         href: '/docs/api/rubi-rs',
       },
     ],

--- a/src/pages/docs/api/subgraphs/rubi-rs.md
+++ b/src/pages/docs/api/subgraphs/rubi-rs.md
@@ -1,0 +1,9 @@
+## rubi-rs
+
+`rubi-rs` is a Rust SDK for interacting with the Rubicon protocol, built on [ethers-rs](https://github.com/gakonst/ethers-rs).
+
+[rubi-rs Repo](https://github.com/RubiconDeFi/rubi-rs)
+
+[View on Crates-io](https://crates.io/crates/rubi)
+
+[rubi-rs Documentation](https://docs.rs/rubi/1.3.1/rubi/)


### PR DESCRIPTION
Adds documentation and links for rubi-rs, a Rust SDK for interacting with the Rubicon protocol.