### PR TITLE
Make Fees less confusing

### DIFF
--- a/pages/protocol/rubicon-market/fees.en.mdx
+++ b/pages/protocol/rubicon-market/fees.en.mdx
@@ -11,22 +11,22 @@ description: Fees on Rubicon
 import { Callout } from "/components/Callout";
 
 <Callout type="fees" title="Protocol Fee: 0.002%">
-	Paid by trades to the protocol. Paid in the token sent to the contract.
+	Paid by takers (buyers) to the protocol. Paid in the token sent from the taker to the contract.
 </Callout>
 
-<Callout type="fees" title="Maker Fee: 0.038%">
-	Paid by the taker to the "maker", the address that owns the filled offer
+<Callout type="fees" title="Maker Rebate: 0.038%">
+	Paid by the taker to the maker (seller), the address that owns the filled offer during a buy.
 </Callout>
 
-The **Taker Fee** is equal to the sum of the **Protocol Fee** and the **Maker Fee**.
+The **Total Taker Fee** is equal to the sum of the **Protocol Fee** and the **Maker Rebate**. All market fees (rebates) are paid in the token the buyer is paying to fill an offer.
 
-<Callout type="fees" title="Taker Fee: 0.04%">
-	Total fee paid by trades that "take" liquidity from the order book. Paid in the token sent to the contract.
+<Callout type="fees" title="Total Taker Fee: 0.04%">
+	Total fee paid by trades that "take" liquidity from the order book (a buy). Paid in the token sent to the contract from the taker.
 </Callout>
 
 ### Querying the Fees
 
-Use these view functions to query the fee values.
+Use these view functions to query the fee values. **Please note that "getFeeBPS" is a semantic misnomer and the integer value it returns is a pip, 1 / 100,000, and represents the input to the protocol fee**. This is maintained for backward compatibility and will be fixed in future updates.
 
 ```solidity copy
 function getFeeBPS()

--- a/pages/protocol/rubicon-market/fees.en.mdx
+++ b/pages/protocol/rubicon-market/fees.en.mdx
@@ -46,8 +46,6 @@ function makerFee()
 
 Returns the current maker fee.
 
-The **Taker Fee** is equal to the sum of the **Protocol Fee** and the **Maker Fee**.
-
 ### Calculating Fees for a Trade
 
 Use `getBuyAmountWithFee()` or `getPayAmountWithFee()` to calculate the total amount to send to the contract for a given trade, including fees.

--- a/pages/protocol/rubicon-market/fees.en.mdx
+++ b/pages/protocol/rubicon-market/fees.en.mdx
@@ -1,7 +1,7 @@
 ---
 title: Fees
 pageTitle: Fees
-description: Fees on the Protocol
+description: Fees on Rubicon
 ---
 
 # Rubicon Market
@@ -10,17 +10,23 @@ description: Fees on the Protocol
 
 import { Callout } from "/components/Callout";
 
-<Callout type="fees" title="Taker Fee: 0.04%">
-	Paid by trades that "take" liquidity from the order book in the token sent to the contract
+<Callout type="fees" title="Protocol Fee: 0.002%">
+	Paid by trades to the protocol. Paid in the token sent to the contract.
 </Callout>
 
 <Callout type="fees" title="Maker Fee: 0.038%">
 	Paid by the taker to the "maker", the address that owns the filled offer
 </Callout>
 
+The **Taker Fee** is equal to the sum of the **Protocol Fee** and the **Maker Fee**.
+
+<Callout type="fees" title="Taker Fee: 0.04%">
+	Total fee paid by trades that "take" liquidity from the order book. Paid in the token sent to the contract.
+</Callout>
+
 ### Querying the Fees
 
-At a technical level, the **Taker Fee** is equal to the sum of the **Protocol Fee** and the **Maker Fee**.
+Use these view functions to query the fee values.
 
 ```solidity copy
 function getFeeBPS()
@@ -39,6 +45,8 @@ function makerFee()
 ```
 
 Returns the current maker fee.
+
+The **Taker Fee** is equal to the sum of the **Protocol Fee** and the **Maker Fee**.
 
 ### Calculating Fees for a Trade
 


### PR DESCRIPTION
Makes the Fees page less confusing by clearly displaying the Protocol Fee, Maker Fee, and Taker Fee.