### PR TITLE
Collapse sidebar by default and promote APIs section

### DIFF
--- a/pages/_meta.en.json
+++ b/pages/_meta.en.json
@@ -2,7 +2,7 @@
 	"index": "Overview",
 	"faq": "FAQ",
 	"protocol": "Protocol",
+	"api-guides": "API",
 	"market-making": "Market Making",
-	"guides": "Guides",
-	"api-guides": "API"
+	"guides": "Guides"
 }

--- a/theme.config.jsx
+++ b/theme.config.jsx
@@ -114,6 +114,9 @@ export default {
 	feedback: {
 		content: Feedback,
 	},
+	sidebar: {
+		defaultMenuCollapseLevel: 1,
+	},
 	search: {},
 	useNextSeoProps() {
 		return {


### PR DESCRIPTION
Adds sets the `sidebar.defaultMenuCollapseLevel` to 1, instead of the default 2. All sidebar items are collapsed by default for greater visibility. Closes #45 

[Relevant Nextra Docs](https://nextra.site/docs/docs-theme/theme-configuration#menu-collapse-level)