### PR TITLE
Remove feeBPS() and replace with protocolFee()

### DIFF
--- a/pages/protocol/rubicon-market/contract-overview.en.mdx
+++ b/pages/protocol/rubicon-market/contract-overview.en.mdx
@@ -223,10 +223,10 @@ Returns the number of offers in the order book for a specified pair.
 ### getFeeBPS()
 
 ```solidity copy
-function getFeeBPS()
-    public
-    view
-    returns (uint256)
+    function protocolFee() 
+        public
+        view 
+        returns (uint256)
 ```
 
 Returns the current protocol fee.

--- a/pages/protocol/rubicon-market/contract-overview.mdx
+++ b/pages/protocol/rubicon-market/contract-overview.mdx
@@ -259,16 +259,25 @@ function getOfferCount(ERC20 sell_gem, ERC20 buy_gem)
 
 Returns the number of offers in the order book for a specified pair.
 
-### getFeeBPS()
-
+```solidity copy
+    function protocolFee() 
+        public
+        view 
+        returns (uint256)
 ```
-function getFeeBPS()
-    public
-    view
+
+Returns the current protocol fee.
+
+### makerFee()
+
+```solidity copy
+function makerFee() 
+    public 
+    view 
     returns (uint256)
 ```
 
-Returns the protocol fee, in basis points.
+Returns the current maker fee.
 
 ## Key Events
 

--- a/pages/protocol/rubicon-market/fees.en.mdx
+++ b/pages/protocol/rubicon-market/fees.en.mdx
@@ -26,13 +26,13 @@ The **Total Taker Fee** is equal to the sum of the **Protocol Fee** and the **Ma
 
 ### Querying the Fees
 
-Use these view functions to query the fee values. **Please note that "getFeeBPS" is a semantic misnomer and the integer value it returns is a pip, 1 / 100,000, and represents the input to the protocol fee**. This is maintained for backward compatibility and will be fixed in future updates.
+Use these view functions to query the fee values.
 
 ```solidity copy
-function getFeeBPS()
-    public
-    view
-    returns (uint256)
+    function protocolFee() 
+        public
+        view 
+        returns (uint256)
 ```
 
 Returns the current protocol fee.

--- a/pages/protocol/rubicon-market/fees.mdx
+++ b/pages/protocol/rubicon-market/fees.mdx
@@ -1,41 +1,86 @@
 ---
 title: Fees
 pageTitle: Fees
-description: Fees on the Rubicon protocol
+description: Fees on Rubicon
 ---
 
-# Fees
+# Rubicon Market
 
-The Rubicon protocol has a maker-taker fee model, charging trades that "take" liquidity from the order book and paying a rebate to orders that "make" liquidity on the order book. The taker fee is paid in the ERC-20 token that is sent to the contract, and the maker fee is paid to the owner address of the filled order(s).
+## Fees
 
-## Fee Schedule
+import { Callout } from "/components/Callout";
 
-|  Name          | Amount | Description                                                   |
-| -------------- | ------ | ------------------------------------------------------------- |
-| Taker          | 0.04%  | Paid by trades that "take" liquidity from the order book      |
-| Maker          | 0.038% | Paid by the taker to the "maker", the owner address of the filled offer(s) |
+<Callout type="fees" title="Protocol Fee: 0.002%">
+	Paid by takers (buyers) to the protocol. Paid in the token sent from the taker to the contract.
+</Callout>
+
+<Callout type="fees" title="Maker Rebate: 0.038%">
+	Paid by the taker to the maker (seller), the address that owns the filled offer during a buy.
+</Callout>
+
+The **Total Taker Fee** is equal to the sum of the **Protocol Fee** and the **Maker Rebate**. All market fees (rebates) are paid in the token the buyer is paying to fill an offer.
+
+<Callout type="fees" title="Total Taker Fee: 0.04%">
+	Total fee paid by trades that "take" liquidity from the order book (a buy). Paid in the token sent to the contract from the taker.
+</Callout>
 
 ### Querying the Fees
 
-At a technical level, the taker fee is equal to the sum of the protocol fee and the maker fee. 
+Use these view functions to query the fee values.
 
-```solidity
-function getFeeBPS()
-    public
-    view
-    returns (uint256)
+```solidity copy
+    function protocolFee() 
+        public
+        view 
+        returns (uint256)
 ```
 
 Returns the current protocol fee.
 
-```solidity
+```solidity copy
 function makerFee() 
     public 
     view 
     returns (uint256)
 ```
 
-Returns the current maker fee (rebate).
+Returns the current maker fee.
+
+### Calculating Fees for a Trade
+
+Use `getBuyAmountWithFee()` or `getPayAmountWithFee()` to calculate the total amount to send to the contract for a given trade, including fees.
+
+```solidity copy
+    function getBuyAmountWithFee(
+        IERC20 buy_gem,
+        IERC20 pay_gem,
+        uint256 pay_amt
+    ) external view returns (uint256 buy_amt, uint256 approvalAmount) {
+        uint modifiedAmount = calculateFees(pay_amt, false);
+        buy_amt = (getBuyAmount(buy_gem, pay_gem, modifiedAmount));
+
+        approvalAmount = pay_amt;
+        return (buy_amt, approvalAmount);
+    }
+```
+
+Returns `buy_amt`, the amount of `buy_gem` tokens to send to the contract to receive the `pay_amt` amount of the `pay_gem` token. Also returns `approvalAmount`, the amount of `pay_gem` tokens to approve for the interaction, accounting for fees.
+
+```solidity copy
+    function getPayAmountWithFee(
+        IERC20 pay_gem,
+        IERC20 buy_gem,
+        uint256 buy_amt
+    ) public view returns (uint256 pay_amt, uint256 approvalAmount) {
+        pay_amt = (getPayAmount(pay_gem, buy_gem, buy_amt));
+        uint modifiedAmount = calculateFees(pay_amt, true);
+
+        approvalAmount = modifiedAmount;
+        return (pay_amt, approvalAmount);
+    }
+```
+
+Returns `pay_amt`, the amount of `pay_gem` tokens to send to the contract to receive the `buy_amt` amount of the `buy_gem` token. Also returns `approvalAmount`, the amount of `buy_gem` tokens to approve for the interaction, accounting for fees.
 
 ## Network Fees
 


### PR DESCRIPTION
Removes the old protocol fee function and replaces it with the new one on the Fees and Contract Overview pages.