### PR TITLE
Fix: #60

### DIFF
--- a/components/DynamicEndpoint.jsx
+++ b/components/DynamicEndpoint.jsx
@@ -96,7 +96,7 @@ export function MakerAddress({ children }) {
         const lowerCaseValue = e.target.value.toLowerCase()
         setInputValue(lowerCaseValue)
         if (tokenRef.current) {
-            tokenRef.current.innerText = lowerCaseValue
+            tokenRef.current.innerText = `"${lowerCaseValue}"`;
         }
     }
 
@@ -147,7 +147,7 @@ export function QuoteAddress({ children }) {
     const handleInputChange = (e) => {
         const lowerCaseValue = e.target.value.toLowerCase()
         setInputValue(lowerCaseValue)
-        tokenRef.current.forEach(token => token.innerText = lowerCaseValue)
+        tokenRef.current.forEach(token => token.innerText = `"${lowerCaseValue}"`);
     }
 
     return (
@@ -198,7 +198,7 @@ export function AssetAddress({ children }) {
     const handleInputChange = (e) => {
         const lowerCaseValue = e.target.value.toLowerCase()
         setInputValue(lowerCaseValue)
-        tokenRef.current.forEach(token => token.innerText = lowerCaseValue)
+        tokenRef.current.forEach(token => token.innerText = `"${lowerCaseValue}"`);
     }
 
     return (

--- a/pages/api-guides/orders/order-data.en.mdx
+++ b/pages/api-guides/orders/order-data.en.mdx
@@ -193,7 +193,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
         first: 1000
         orderBy: price
         orderDirection: desc
-        where: {pay_gem: "0xasset", buy_gem: "0xquote", open: true}
+        where: {pay_gem: "0xquote", buy_gem: "0xasset", open: true}
     ) {
         # the id of the offer
         id

--- a/pages/api-guides/orders/order-data.mdx
+++ b/pages/api-guides/orders/order-data.mdx
@@ -193,7 +193,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
         first: 1000
         orderBy: price
         orderDirection: desc
-        where: {pay_gem: "0xasset", buy_gem: "0xquote", open: true}
+        where: {pay_gem: "0xquote", buy_gem: "0xasset", open: true}
     ) {
         # the id of the offer
         id

--- a/pages/api-guides/orders/trade-data.en.mdx
+++ b/pages/api-guides/orders/trade-data.en.mdx
@@ -24,7 +24,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
     <QuoteAddress>
     ```graphql copy
     {
-    buys: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+    buys: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
             where: {take_gem: "0xasset", give_gem: "0xquote"}) {
         take_gem
         take_amt
@@ -44,7 +44,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
         }
     }
     
-    sells: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+    sells: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
             where: {take_gem: "0xquote", give_gem: "0xasset"}) {
         take_gem
         take_amt
@@ -85,7 +85,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
 
     query = f"""
     {{
-    buys: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+    buys: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
             where: {{take_gem: "{asset}", give_gem: "{quote}"}}) {{
         take_gem
         take_amt
@@ -105,7 +105,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
         }}
     }}
     
-    sells: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+    sells: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
             where: {{take_gem: "{quote}", give_gem: "{asset}"}}) {{
         take_gem
         take_amt
@@ -155,7 +155,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
         let query = format!(
             r#"
             {
-            buys: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+            buys: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
                     where: {take_gem: "{}", give_gem: "{}"}) {
                 take_gem
                 take_amt
@@ -175,7 +175,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
                 }
             }
             
-            sells: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+            sells: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
                     where: {take_gem: "{}", give_gem: "{}"}) {
                 take_gem
                 take_amt
@@ -234,7 +234,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
 
     const query = `
         {
-        buys: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+        buys: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
                 where: {take_gem: "${asset}", give_gem: "${quote}"}) {
             take_gem
             take_amt
@@ -254,7 +254,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
             }
         }
         
-        sells: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+        sells: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
                 where: {take_gem: "${quote}", give_gem: "${asset}"}) {
             take_gem
             take_amt
@@ -297,7 +297,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
     <MakerAddress>
     ```graphql copy
     {
-    buys: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+    buys: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
             where:  {offer_ : { maker: "0xinput_address" }}) {
         take_gem
         take_amt
@@ -317,7 +317,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
         }
     }
     
-    sells: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+    sells: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
             where:  {offer_ : { maker: "0xinput_address" }}) {
         take_gem
         take_amt
@@ -356,7 +356,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
 
     query = f"""
     {{
-    buys: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+    buys: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
             where: {{offer_ : {{ maker: "{maker}" }}}}) {{
         take_gem
         take_amt
@@ -376,7 +376,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
         }}
     }}
     
-    sells: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+    sells: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
             where: {{offer_ : {{ maker: "{maker}" }}) {{
         take_gem
         take_amt
@@ -426,7 +426,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
         let query = format!(
             r#"
             {
-            buys: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+            buys: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
                     where: {offer_ : { maker: {} }}) {
                 take_gem
                 take_amt
@@ -446,7 +446,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
                 }
             }
             
-            sells: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+            sells: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
                     where: {offer_ : { maker: {} }}) {
                 take_gem
                 take_amt
@@ -504,7 +504,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
 
     const query = `
         {
-        buys: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+        buys: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
                 where: {offer_ : { maker: "${maker} }}) {
             take_gem
             take_amt
@@ -524,7 +524,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
             }
         }
         
-        sells: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+        sells: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
                 where: {offer_ : { maker: "${maker} }}) {
             take_gem
             take_amt

--- a/pages/api-guides/orders/trade-data.mdx
+++ b/pages/api-guides/orders/trade-data.mdx
@@ -24,7 +24,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
     <QuoteAddress>
     ```graphql copy
     {
-    buys: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+    buys: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
             where: {take_gem: "0xasset", give_gem: "0xquote"}) {
         take_gem
         take_amt
@@ -44,7 +44,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
         }
     }
     
-    sells: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+    sells: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
             where: {take_gem: "0xquote", give_gem: "0xasset"}) {
         take_gem
         take_amt
@@ -85,7 +85,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
 
     query = f"""
     {{
-    buys: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+    buys: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
             where: {{take_gem: "{asset}", give_gem: "{quote}"}}) {{
         take_gem
         take_amt
@@ -105,7 +105,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
         }}
     }}
     
-    sells: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+    sells: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
             where: {{take_gem: "{quote}", give_gem: "{asset}"}}) {{
         take_gem
         take_amt
@@ -155,7 +155,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
         let query = format!(
             r#"
             {
-            buys: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+            buys: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
                     where: {take_gem: "{}", give_gem: "{}"}) {
                 take_gem
                 take_amt
@@ -175,7 +175,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
                 }
             }
             
-            sells: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+            sells: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
                     where: {take_gem: "{}", give_gem: "{}"}) {
                 take_gem
                 take_amt
@@ -234,7 +234,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
 
     const query = `
         {
-        buys: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+        buys: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
                 where: {take_gem: "${asset}", give_gem: "${quote}"}) {
             take_gem
             take_amt
@@ -254,7 +254,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
             }
         }
         
-        sells: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+        sells: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
                 where: {take_gem: "${quote}", give_gem: "${asset}"}) {
             take_gem
             take_amt
@@ -297,7 +297,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
     <MakerAddress>
     ```graphql copy
     {
-    buys: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+    buys: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
             where:  {offer_ : { maker: "0xinput_address" }}) {
         take_gem
         take_amt
@@ -317,7 +317,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
         }
     }
     
-    sells: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+    sells: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
             where:  {offer_ : { maker: "0xinput_address" }}) {
         take_gem
         take_amt
@@ -356,7 +356,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
 
     query = f"""
     {{
-    buys: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+    buys: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
             where: {{offer_ : {{ maker: "{maker}" }}}}) {{
         take_gem
         take_amt
@@ -376,7 +376,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
         }}
     }}
     
-    sells: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+    sells: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
             where: {{offer_ : {{ maker: "{maker}" }}) {{
         take_gem
         take_amt
@@ -426,7 +426,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
         let query = format!(
             r#"
             {
-            buys: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+            buys: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
                     where: {offer_ : { maker: {} }}) {
                 take_gem
                 take_amt
@@ -446,7 +446,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
                 }
             }
             
-            sells: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+            sells: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
                     where: {offer_ : { maker: {} }}) {
                 take_gem
                 take_amt
@@ -504,7 +504,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
 
     const query = `
         {
-        buys: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+        buys: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
                 where: {offer_ : { maker: "${maker} }}) {
             take_gem
             take_amt
@@ -524,7 +524,7 @@ import { DynamicEndpoint, MakerAddress, AssetAddress, QuoteAddress } from "/comp
             }
         }
         
-        sells: takes(first: 1000, orderBy:transaction__timestamp, orderDirection:desc,
+        sells: takes(first: 1000, orderBy:timestamp, orderDirection:desc,
                 where: {offer_ : { maker: "${maker} }}) {
             take_gem
             take_amt


### PR DESCRIPTION
this pr corrects the issues outlined in #60: 

- [x] corrects the dynamic inputs to wrap with quotations
- [x] corrects the query to utilize `timestamp` instead of `transaction__timestamp` 

also corrects a small error in the `List Open Orders by Pair`  `graphQL` query