### PR TITLE
update: remove rust sdk while wip #57

### DIFF
--- a/pages/market-making/market-making-overview.en.mdx
+++ b/pages/market-making/market-making-overview.en.mdx
@@ -53,14 +53,6 @@ Python library for interacting with Rubicon, complete with examples and document
   - [View Package](https://pypi.org/project/rubi/)
   - [Source Code Repo](https://github.com/RubiconDeFi/rubi-py)
 
-### Rust SDK (WIP)
-
-Rust library for interacting with Rubicon. (Not ready for production use)
-
-  - [SDK Docs](https://docs.rs/rubi/latest/rubi/)
-  - [View Crate](https://crates.io/crates/rubi)
-  - [Source Code Repo](https://github.com/RubiconDeFi/rubi-rs)
-
 ## Questions and Support
 
 Ask onboarding questions in the Rubicon **[Discord server](https://discord.com/invite/E7pS24J)** or send a note to **integrations@rubicon.finance**.

--- a/pages/market-making/market-making-overview.mdx
+++ b/pages/market-making/market-making-overview.mdx
@@ -53,14 +53,6 @@ Python library for interacting with Rubicon, complete with examples and document
   - [View Package](https://pypi.org/project/rubi/)
   - [Source Code Repo](https://github.com/RubiconDeFi/rubi-py)
 
-### Rust SDK (WIP)
-
-Rust library for interacting with Rubicon. (Not ready for production use)
-
-  - [SDK Docs](https://docs.rs/rubi/latest/rubi/)
-  - [View Crate](https://crates.io/crates/rubi)
-  - [Source Code Repo](https://github.com/RubiconDeFi/rubi-rs)
-
 ## Questions and Support
 
 Ask onboarding questions in the Rubicon **[Discord server](https://discord.com/invite/E7pS24J)** or send a note to **integrations@rubicon.finance**.


### PR DESCRIPTION
removes the mention of `rubi-rs` from the marketing making overview while it is still a `WIP`