### PR TITLE
Add Base Mainnet Contract Addresses

### DIFF
--- a/pages/protocol/deployments.en.mdx
+++ b/pages/protocol/deployments.en.mdx
@@ -26,6 +26,14 @@ Please note that Rubicon utilizes the [transparent upgradeable proxy standard](h
 | RubiconRouter   | [0x7b24e6f4dd84674696c2a5809c24154ec6ac7f03](https://arbiscan.io/address/0x7b24e6f4dd84674696c2a5809c24154ec6ac7f03) |
 | MarketAidFactory| [0x6CB24A263732579EfD56f3E071851e989d78cE75](https://arbiscan.io/address/0x6cb24a263732579efd56f3e071851e989d78ce75) |
 
+### Base
+
+| Contract Name   | Address                                      |
+| --------------- | -------------------------------------------- |
+| RubiconMarket   | [0x9A5215E96E1185d4e6002C95C3Cc0aB6eEaD354F](https://basescan.org/address/0x9A5215E96E1185d4e6002C95C3Cc0aB6eEaD354F) |
+| RubiconRouter   | [0x929675f6a6aC12D7cC3463BE1df7221ca35b8a00](https://basescan.org/address/0x929675f6a6aC12D7cC3463BE1df7221ca35b8a00) |
+| MarketAidFactory| [0xc2b33a7601f3f0ecFF2eE4b5b7c647770069A836](https://basescan.org/address/0xc2b33a7601f3f0ecFF2eE4b5b7c647770069A836) |
+
 ## Testnet Deployments
 
 List of contract addresses on various test networks. Includes addresses for test tokens with a built-in faucet, you can mint these tokens by calling faucet() on the contract or by using the Faucet button in the app.

--- a/pages/protocol/deployments.mdx
+++ b/pages/protocol/deployments.mdx
@@ -26,6 +26,14 @@ Please note that Rubicon utilizes the [transparent upgradeable proxy standard](h
 | RubiconRouter   | [0x7b24e6f4dd84674696c2a5809c24154ec6ac7f03](https://arbiscan.io/address/0x7b24e6f4dd84674696c2a5809c24154ec6ac7f03) |
 | MarketAidFactory| [0x6CB24A263732579EfD56f3E071851e989d78cE75](https://arbiscan.io/address/0x6cb24a263732579efd56f3e071851e989d78ce75) |
 
+### Base
+
+| Contract Name   | Address                                      |
+| --------------- | -------------------------------------------- |
+| RubiconMarket   | [0x9A5215E96E1185d4e6002C95C3Cc0aB6eEaD354F](https://basescan.org/address/0x9A5215E96E1185d4e6002C95C3Cc0aB6eEaD354F) |
+| RubiconRouter   | [0x929675f6a6aC12D7cC3463BE1df7221ca35b8a00](https://basescan.org/address/0x929675f6a6aC12D7cC3463BE1df7221ca35b8a00) |
+| MarketAidFactory| [0xc2b33a7601f3f0ecFF2eE4b5b7c647770069A836](https://basescan.org/address/0xc2b33a7601f3f0ecFF2eE4b5b7c647770069A836) |
+
 ## Testnet Deployments
 
 List of contract addresses on various test networks. Includes addresses for test tokens with a built-in faucet, you can mint these tokens by calling faucet() on the contract or by using the Faucet button in the app.


### PR DESCRIPTION
Adds Base Mainnet contract addresses to the Deployments page.